### PR TITLE
Support concurrency

### DIFF
--- a/tests/integration/examples/simple/actions.py
+++ b/tests/integration/examples/simple/actions.py
@@ -3,7 +3,12 @@ from gadk import *
 
 class MyService(Workflow):
     def __init__(self) -> None:
-        super().__init__("my_service", "my service workflow")
+        super().__init__(
+            "my_service",
+            "my service workflow",
+            concurrency_group='${{ github.workflow }}-${{ github.head_ref || github.run_id }}',
+            cancel_in_progress=True,
+        )
 
         paths = [
             "src/service/*.py",

--- a/tests/integration/examples/simple/expected.yml
+++ b/tests/integration/examples/simple/expected.yml
@@ -1,5 +1,8 @@
 # This file is managed by gadk. For more information see https://pypi.org/project/gadk/.
 name: my service workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 'on':
   pull_request:
     paths:

--- a/tests/unit/test_elements.py
+++ b/tests/unit/test_elements.py
@@ -1,6 +1,19 @@
 from gadk import *
 
 
+class TestWorkflow:
+    def test_simple_concurrency(self):
+        workflow = Workflow("foo", concurrency_group="my_group")
+        assert workflow.to_yaml() == {"concurrency": "my_group", "on": {}}
+
+    def test_cancel_in_progress_concurrency(self):
+        workflow = Workflow("foo", concurrency_group="my_group", cancel_in_progress=True)
+        assert workflow.to_yaml() == {
+            "concurrency": {"group": "my_group", "cancel-in-progress": True},
+            "on": {},
+        }
+
+
 class TestWorkflowOn:
     def test_on_only_push(self):
         workflow = Workflow("foo")


### PR DESCRIPTION
This PR adds support for concurrency groups and cancelling in-progress runs, as per [the Actions docs][1].

[1]: https://docs.github.com/en/actions/using-jobs/using-concurrency